### PR TITLE
Fix experience earned, when the hero level is greater than opponent level+5

### DIFF
--- a/app/Timongo/Battle/PvE.php
+++ b/app/Timongo/Battle/PvE.php
@@ -77,13 +77,9 @@ class PvE
     {
         $goldDrop = $opponent->getGoldDrop();
 
-        $expEarned = $this->expEarned($opponent->experience, $hero->learning_level);
+        $expEarned = $this->expEarned($hero, $opponent);
 
-        if ($hero->level >= ($opponent->level + 5)) {
-            $expEarned /= 3;
-        }
-
-        $hero->experience += intval($expEarned);
+        $hero->experience += $expEarned;
         $hero->gold += $goldDrop;
 
         return [
@@ -107,11 +103,17 @@ class PvE
         ];
     }
 
-    private function expEarned($expEarned, $learningLevel)
+    private function expEarned($hero, $opponent)
     {
-        return (int) round(
-            ceil(($expEarned) + ($expEarned * 0.05 * $learningLevel))
+        $expEarned = round(
+            ceil(($opponent->experience) + ($opponent->experience * 0.04 * $hero->learningLevel))
         );
+
+        if ($hero->level >= ($opponent->level + 5)) {
+            $expEarned = $expEarned / 3;
+        }
+
+        return (int) $expEarned;
     }
 
     protected function getCreature($creatureId)


### PR DESCRIPTION
In my last PR  https://github.com/timongorpg/timongo/commit/3540c76aab0afcfa82cc6d3db68d0f801ff05362 that fix the experience earned, I notice that I forgot to test an use case(When the hero level is greater than opponent level+5). 

So this PR fix the experience earned.

Sorry for my mistake 😞 
